### PR TITLE
Removed discord.js and use webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@discordjs/builders": "^1.6.5",
+    "@discordjs/builders": "1.6.5",
     "@octokit/rest": "20.0.1",
     "@t3-oss/env-core": "0.6.1",
-    "discord-api-types": "^0.37.56",
+    "discord-api-types": "0.37.56",
     "dotenv": "16.3.1",
-    "undici": "^5.23.0",
+    "undici": "5.23.0",
     "zod": "3.22.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@discordjs/builders": "^1.6.5",
     "@octokit/rest": "20.0.1",
     "@t3-oss/env-core": "0.6.1",
-    "discord.js": "14.13.0",
+    "discord-api-types": "^0.37.56",
     "dotenv": "16.3.1",
+    "undici": "^5.23.0",
     "zod": "3.22.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,18 +5,24 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@discordjs/builders':
+    specifier: ^1.6.5
+    version: 1.6.5
   '@octokit/rest':
     specifier: 20.0.1
     version: 20.0.1
   '@t3-oss/env-core':
     specifier: 0.6.1
     version: 0.6.1(typescript@5.2.2)(zod@3.22.2)
-  discord.js:
-    specifier: 14.13.0
-    version: 14.13.0
+  discord-api-types:
+    specifier: ^0.37.56
+    version: 0.37.56
   dotenv:
     specifier: 16.3.1
     version: 16.3.1
+  undici:
+    specifier: ^5.23.0
+    version: 5.23.0
   zod:
     specifier: 3.22.2
     version: 3.22.2
@@ -294,11 +300,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@discordjs/collection@1.5.3:
-    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
-    engines: {node: '>=16.11.0'}
-    dev: false
-
   /@discordjs/formatters@0.3.2:
     resolution: {integrity: sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==}
     engines: {node: '>=16.11.0'}
@@ -306,42 +307,9 @@ packages:
       discord-api-types: 0.37.50
     dev: false
 
-  /@discordjs/rest@2.0.1:
-    resolution: {integrity: sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==}
-    engines: {node: '>=16.11.0'}
-    dependencies:
-      '@discordjs/collection': 1.5.3
-      '@discordjs/util': 1.0.1
-      '@sapphire/async-queue': 1.5.0
-      '@sapphire/snowflake': 3.5.1
-      '@vladfrangu/async_event_emitter': 2.2.2
-      discord-api-types: 0.37.50
-      magic-bytes.js: 1.0.15
-      tslib: 2.6.2
-      undici: 5.22.1
-    dev: false
-
   /@discordjs/util@1.0.1:
     resolution: {integrity: sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==}
     engines: {node: '>=16.11.0'}
-    dev: false
-
-  /@discordjs/ws@1.0.1:
-    resolution: {integrity: sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==}
-    engines: {node: '>=16.11.0'}
-    dependencies:
-      '@discordjs/collection': 1.5.3
-      '@discordjs/rest': 2.0.1
-      '@discordjs/util': 1.0.1
-      '@sapphire/async-queue': 1.5.0
-      '@types/ws': 8.5.5
-      '@vladfrangu/async_event_emitter': 2.2.2
-      discord-api-types: 0.37.50
-      tslib: 2.6.2
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
     dev: false
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.48.0):
@@ -599,22 +567,12 @@ packages:
     resolution: {integrity: sha512-0xd7qez0AQ+MbHatZTlI1gu5vkG8r7MYRUJAHPAHJBmGLs16zpkrpAVLvjQKQOqaXPDUBwOiJzNc00znHSCVBw==}
     dev: true
 
-  /@sapphire/async-queue@1.5.0:
-    resolution: {integrity: sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-    dev: false
-
   /@sapphire/shapeshift@3.9.2:
     resolution: {integrity: sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dependencies:
       fast-deep-equal: 3.1.3
       lodash: 4.17.21
-    dev: false
-
-  /@sapphire/snowflake@3.5.1:
-    resolution: {integrity: sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
     dev: false
 
   /@t3-oss/env-core@0.6.1(typescript@5.2.2)(zod@3.22.2):
@@ -653,6 +611,7 @@ packages:
 
   /@types/node@20.5.9:
     resolution: {integrity: sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==}
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -661,12 +620,6 @@ packages:
   /@types/semver@7.5.1:
     resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
     dev: true
-
-  /@types/ws@8.5.5:
-    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
-    dependencies:
-      '@types/node': 20.5.9
-    dev: false
 
   /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.2.2):
     resolution: {integrity: sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==}
@@ -907,11 +860,6 @@ packages:
       - jest
       - supports-color
     dev: true
-
-  /@vladfrangu/async_event_emitter@2.2.2:
-    resolution: {integrity: sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
-    dev: false
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -1357,27 +1305,8 @@ packages:
     resolution: {integrity: sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg==}
     dev: false
 
-  /discord.js@14.13.0:
-    resolution: {integrity: sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==}
-    engines: {node: '>=16.11.0'}
-    dependencies:
-      '@discordjs/builders': 1.6.5
-      '@discordjs/collection': 1.5.3
-      '@discordjs/formatters': 0.3.2
-      '@discordjs/rest': 2.0.1
-      '@discordjs/util': 1.0.1
-      '@discordjs/ws': 1.0.1
-      '@sapphire/snowflake': 3.5.1
-      '@types/ws': 8.5.5
-      discord-api-types: 0.37.50
-      fast-deep-equal: 3.1.3
-      lodash.snakecase: 4.1.1
-      tslib: 2.6.2
-      undici: 5.22.1
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
+  /discord-api-types@0.37.56:
+    resolution: {integrity: sha512-Ih3wj0ZTaQxaJRqUEXHMIXfXB86bwMGC0wc2nNsyCJqeo3lC4qnxXtFIsC+IGI46+dSIinuayCAZ6sLEEM02Bw==}
     dev: false
 
   /doctrine@2.1.0:
@@ -2616,10 +2545,6 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
-  /lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
-    dev: false
-
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -2642,10 +2567,6 @@ packages:
     dependencies:
       yallist: 4.0.0
     dev: true
-
-  /magic-bytes.js@1.0.15:
-    resolution: {integrity: sha512-bpRmwbRHqongRhA+mXzbLWjVy7ylqmfMBYaQkSs6pac0z6hBTvsgrH0r4FBYd/UYVJBmS6Rp/O+oCCQVLzKV1g==}
-    dev: false
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -3530,8 +3451,8 @@ packages:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
 
-  /undici@5.22.1:
-    resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
+  /undici@5.23.0:
+    resolution: {integrity: sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==}
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
@@ -3632,19 +3553,6 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  /ws@8.13.0:
-    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: false
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   '@discordjs/builders':
-    specifier: ^1.6.5
+    specifier: 1.6.5
     version: 1.6.5
   '@octokit/rest':
     specifier: 20.0.1
@@ -15,13 +15,13 @@ dependencies:
     specifier: 0.6.1
     version: 0.6.1(typescript@5.2.2)(zod@3.22.2)
   discord-api-types:
-    specifier: ^0.37.56
+    specifier: 0.37.56
     version: 0.37.56
   dotenv:
     specifier: 16.3.1
     version: 16.3.1
   undici:
-    specifier: ^5.23.0
+    specifier: 5.23.0
     version: 5.23.0
   zod:
     specifier: 3.22.2

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,6 @@ It doesn't require the repository owner to configure anything. Instead it just p
    - `REPO_OWNER`: The owner of the GitHub repository (e.g. `vercel`)
    - `REPO_NAME`: The name of the GitHub repository (e.g. `next.js`)
    - `GITHUB_TOKEN` (optional): A GitHub personal access token (with the **repo** scope) to access the repository (only necessary if the repository is not public)
-   - `RELEASE_PING_ROLE_ID` and `PRERELEASE_PING_ROLE_ID`: The ping role IDs if you want the bot to ping. The bot also needs the "Mention Everyone" permission for the ping to work.
+   - `RELEASE_PING_ROLE_ID` and `PRERELEASE_PING_ROLE_ID`: The ping role IDs if you want the bot to ping. The channel also needs the "Mention Everyone" permission for everyone to work.
 
 3. The classic steps: `pnpm install`, `pnpm dev` for development, `pnpm build && pnpm start` for deployment.

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,7 @@ It doesn't require the repository owner to configure anything. Instead it just p
 
 2. Add the necessary environment variables:
 
-   - `DISCORD_TOKEN`: The bot token
-   - `RELEASE_CHANNEL_ID`: The release channel ID where the bot will post messages
+   - `DISCORD_WEBHOOK`: The webhook url
    - `REPO_OWNER`: The owner of the GitHub repository (e.g. `vercel`)
    - `REPO_NAME`: The name of the GitHub repository (e.g. `next.js`)
    - `GITHUB_TOKEN` (optional): A GitHub personal access token (with the **repo** scope) to access the repository (only necessary if the repository is not public)

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,7 +6,7 @@ config();
 
 export const env = createEnv({
   server: {
-    DISCORD_WEBHOOK: z.string().min(1),
+    DISCORD_WEBHOOK: z.string().url(),
     GITHUB_TOKEN: z.string().min(1).optional(),
     REPO_OWNER: z.string().min(1),
     REPO_NAME: z.string().min(1),

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,8 +6,7 @@ config();
 
 export const env = createEnv({
   server: {
-    DISCORD_TOKEN: z.string().min(1),
-    RELEASE_CHANNEL_ID: z.string().min(1),
+    DISCORD_WEBHOOK: z.string().min(1),
     GITHUB_TOKEN: z.string().min(1).optional(),
     REPO_OWNER: z.string().min(1),
     REPO_NAME: z.string().min(1),

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ class GitHubRelease {
   private readonly body: string;
   private readonly isPrerelease: boolean;
 
-  private static readonly STABLE_COLOUR = 0x0072F7;
-  private static readonly PRERELEASE_COLOUR = 0xFFB11A;
+  private static readonly STABLE_COLOUR = 0x0072f7;
+  private static readonly PRERELEASE_COLOUR = 0xffb11a;
 
   public constructor(
     release: RestEndpointMethodTypes["repos"]["listReleases"]["response"]["data"][number],
@@ -94,7 +94,7 @@ class LastUpdatedStore {
 }
 
 class ReleaseChecker {
-  private readonly octokit = new Octokit({ auth: env.GITHUB_TOKEN });
+  private readonly octokit = new Octokit({ auth: env.GITHUB_TOKEN, request: { fetch } });
   private readonly lastUpdatedStore = new LastUpdatedStore();
 
   options = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ class GitHubRelease {
 class LastUpdatedStore {
   private readonly lastUpdated: Date;
   public constructor() {
-    this.lastUpdated = new Date(1);
+    this.lastUpdated = new Date();
   }
   public releaseIsNewer(release: GitHubRelease): boolean {
     return release.getTime() > this.lastUpdated;


### PR DESCRIPTION
This PR removes the usage of Discord.js and instead uses webhooks to send message

IMPORTANT:
* removed `DISCORD_TOKEN` and `RELEASE_CHANNEL_ID`
* added `DISCORD_WEBHOOK`
* the channel needs the permission to ping instead of the bot (no-one can send message there, so not much abuse possible)

Info:
* used undici because nodejs fetch wasn't working for TS
* installed `discord-api-types` and `@discordjs/builders` to keep the types and methods as similar as possible
* converted hex strings to hex representation because  `@discordjs/builders` doesn't actually parse it (`discord.js` adds a wrapper on top of it)
* if you want to throw an error if can't sent message, you would need to check the value of the fetch request and add `?wait-true` to the end of url
